### PR TITLE
Update configuration to please publishing to Gradle Plugin Portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ gradlePlugin {
         simplePlugin {
             id = 'org.rewedigital.frost'
             implementationClass = 'org.rewedigital.frost.FrostPlugin'
+            displayName = 'FROST system test runtime'
+            description = 'Creates a system test runtime to enable powerful UI testing during your CI build.'
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 plugins {
     id 'java-gradle-plugin'
+    id 'com.gradle.plugin-publish' version '0.10.0'
 }
+
+apply from: 'publish-to-plugin-portal.gradle'
 
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'

--- a/publish-to-plugin-portal.gradle
+++ b/publish-to-plugin-portal.gradle
@@ -1,0 +1,5 @@
+pluginBundle {
+    website = 'https://github.com/rewe-digital-incubator/frost'
+    vcsUrl = 'https://github.com/rewe-digital-incubator/frost.git'
+    tags = ['testing', 'selenium', 'galen', 'docker']
+}


### PR DESCRIPTION
I factored the publishing-relevant code into `publish-to-plugin-portal.gradle` and keep `build.gradle` free from it.

In order to make it working I have the following local changes that are not in VCS:
```
diff --git a/build.gradle b/build.gradle
index 4fa5af3..ea2be7b 100644
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,10 @@
 plugins {
     id 'java-gradle-plugin'
+    id 'com.gradle.plugin-publish' version '0.10.0'
 }
 
+apply from: 'publish-to-plugin-portal.gradle'
+
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 apply plugin: 'maven'
```